### PR TITLE
fix: do not add letterSpacing after last char

### DIFF
--- a/src/bounty.js
+++ b/src/bounty.js
@@ -203,6 +203,7 @@ export default ({
 
       canvasWidth += width + letterSpacing;
     });
+    canvasWidth -= letterSpacing;
 
     chars.forEach(char => {
       char.node::attr('transform', `translate(${char.offset.x}, ${char.offset.y})`);


### PR DESCRIPTION
this also prevents canvas crop for negative letterSpacing (useful for small font-sizes)