### PR TITLE
fix: use childNodes because Microsoft Edge doesn't have children for this node

### DIFF
--- a/src/bounty.js
+++ b/src/bounty.js
@@ -194,7 +194,7 @@ export default ({
       char.offset.x = canvasWidth;
       // set proper kerning for proportional fonts
       if (char.isDigit) {
-        [...char.node.children].forEach(element => {
+        [...char.node.childNodes].forEach(element => {
           const { width: letterWidth } = element.getBBox();
           const offset = (width - letterWidth) / 2;
           element.setAttribute('x', offset);


### PR DESCRIPTION
char.node.children is undefined on Microsoft Edge, so bounty crashes (infinite errors in console) on that browser, including all mobile devices... this simple fix solves this problem and works also on other browsers